### PR TITLE
Fix Form

### DIFF
--- a/uqcs/templates/form.mako
+++ b/uqcs/templates/form.mako
@@ -162,10 +162,18 @@
       </div>
       <input type="hidden" name="stripeToken" value="" id="stripeToken" />
       <input
+        class="btn btn-primary"
+        name="submit"
+        type="submit"
+        id="payonline_submit"
+        value="Pay Online"
+      />
+      <input
         class="btn btn-success"
         type="submit"
         name="submission"
         value="Pay Online"
+        style="display:none;"
         id="submitbtn"
       />
       <input
@@ -208,7 +216,7 @@
       $("#submitbtn").click();
     }
   });
-  $("#submitbtn").on("click", function(e) {
+  $("#payonline_submit").on("click", function(e) {
     e.preventDefault();
     if (!$("#fullForm")[0].checkValidity()) {
       return;


### PR DESCRIPTION
This PR fixes a current issue with the signup page whereby a hidden button was removed from the page. This hidden button was used to submit the member details form when the stripe payment completed successfully. By removing the button and joining the two, the form was never submitted when paying by card and the transaction was recursively called.

This PR should fix that issue.