### PR TITLE
Flush and expunge user before enqueuing (closes #33)

### DIFF
--- a/uqcs/admin.py
+++ b/uqcs/admin.py
@@ -137,6 +137,8 @@ def paid(s, admin_user, member_id):
         return abort(400, "Invalid or missing payment parameter. Must be one of " + str(valid_payment))
     user = s.query(m.Member).filter(m.Member.id == member_id).one()
     user.paid = payment_method
+    s.flush()
+    s.expunge(user)
     mailchimp_queue.put(user)
     mailer_queue.put(user)
     return redirect("/admin/accept", 303)

--- a/uqcs/app.py
+++ b/uqcs/app.py
@@ -118,6 +118,7 @@ def form(s):
             flash(msg, 'danger')
             return redirect('/', 303)
         s.add(user)
+        
         if request.form['stripeToken'].strip():
             try:
                 charge = stripe.Charge.create(
@@ -128,6 +129,9 @@ def form(s):
                 )
                 user.paid = charge['id']
                 session['email'] = user.email
+                
+                s.flush()
+                s.expunge(user)
                 mailer_queue.put(user)
                 mailchimp_queue.put(user)
                 
@@ -137,6 +141,8 @@ def form(s):
                 flash(e.message, "danger")
                 return redirect('/payment', 303)
         else:
+            s.flush()
+            s.expunge(user)
             mailchimp_queue.put(user)
             session['email'] = user.email
             session.pop('form', None)


### PR DESCRIPTION
This _should_ fix #33. However, it's not really testable because I can't reproduce #33 locally.

I gather that flush() writes all changes to the DB, then expunge() disconnects the user object from the DB. This object can then be used in the workers as a plain data object without an active session.

Storing the IDs in the queue did not work because the workers do not run inside a SQLA app context.